### PR TITLE
Fix ReplyForm state access warning

### DIFF
--- a/src/components/ReplyCollapse.js
+++ b/src/components/ReplyCollapse.js
@@ -44,7 +44,7 @@ class ReplyCollapse extends Component {
           <div className="collapsible-body">
             <ReplyForm
               ticket={this.props.ticket}
-              collapse={this.collapse}
+              onReply={this.collapse}
             />
           </div>
         </li>

--- a/src/components/ReplyForm.js
+++ b/src/components/ReplyForm.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import M from 'materialize-css';
 import {
@@ -79,7 +80,7 @@ class ReplyForm extends Component {
               // copy of the Ticket being updated.
               console.log(ticket);
               this.props.setTicket(ticket);
-              this.props.collapse(); // Collapse dialog
+              this.props.onReply();
             })
             .catch(error => {
               console.error(error);
@@ -88,7 +89,7 @@ class ReplyForm extends Component {
               });
             });
         } else {
-          this.props.collapse(); // Collapse dialog
+          this.props.onReply();
         }
 
       });
@@ -178,6 +179,11 @@ class ReplyForm extends Component {
     );
   }
 }
+
+ReplyForm.propTypes = {
+  ticket: PropTypes.object.isRequired,
+  onReply: PropTypes.func
+};
 
 const mapDispatch = (dispatch, ownProps) => ({
   addReply: (reply) =>dispatch({

--- a/src/pages/help/support/Ticket.test.js
+++ b/src/pages/help/support/Ticket.test.js
@@ -514,11 +514,7 @@ describe('Ticket page', () => {
     });
     node.update();
 
-    await act(async () => {
-      replyForm.simulate('submit');
-    });
-    node.update();
-
+    // We should have changed to closed status.
     expectSelectValue("closed");
 
     // Unmount our node.


### PR DESCRIPTION
This commit relates to https://github.com/kevr/breakscheduler/issues/6

The bug was caused by redundantly simulating a submit event
on the form, after clicking a button that caused it.

Thus, we were trying to use a component that was not mounted anymore.

* Additionally, change ReplyForm's finisher callback from
  props.collapse to props.onReply. ReplyCollapse is the
  only thing worried about collapsing itself in the even
  that a reply is sent.
  onReply will always be called whenever a reply is
  successfully submitted by ReplyForm.

Signed-off-by: Kevin Morris <kmorris@zerocost.dev>